### PR TITLE
allow menu bar to show in macos

### DIFF
--- a/src/tavi/frontend/view/main_view.py
+++ b/src/tavi/frontend/view/main_view.py
@@ -65,12 +65,15 @@ class TaviView(QMainWindow):
         logger.info(f"Tavi version: {__version__}")
 
         self.setWindowTitle(f"TAVI - {__version__}")
+
         self.main_window = MainWindow(self)
         self.setCentralWidget(self.main_window)
         self._force_closing = False
 
     def install_menu_bar(self, menu_bar: QMenuBar) -> None:
         """MainPresenter to attach the menu bar."""
+        # Embedded menu bar is more reliable than native mode on macOS/QtPy.
+        menu_bar.setNativeMenuBar(False)
         self.setMenuBar(menu_bar)
 
     def closeEvent(self, event: Any) -> None:


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
Tested on linux, the change does not affect linux. It's a very small change so just merging the pr.

Somehow native menubar would not show in macOS. Seems like documented issue with qt.
Without the change 
<img width="326" height="339" alt="Screenshot 2026-04-22 at 11 44 21 AM" src="https://github.com/user-attachments/assets/743545fd-b58f-40b9-b23b-dcc41d65daaa" />
With the added change
<img width="329" height="370" alt="image" src="https://github.com/user-attachments/assets/13ff7051-dc94-4528-80a9-e0f05d77773e" />

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
