### PR TITLE
scale ellipse based on the min/max of x and y axis

### DIFF
--- a/src/tavi/library/plot/plot_ellipse.py
+++ b/src/tavi/library/plot/plot_ellipse.py
@@ -251,20 +251,17 @@ class PlotResolution:
 
         shear = Affine2D().skew_deg(90 - self.axes_angle, 0)
 
-        x_min, x_max = np.inf, -np.inf
-        y_min, y_max = np.inf, -np.inf
+        lo, hi = np.inf, -np.inf
 
         for entry in self.entries:
             entry.patch.set_transform(shear + ax.transData)
             ax.add_patch(entry.patch)
             x0, y0 = entry.origin
-            x_min = min(x_min, x0 - pad * entry.x_extent)
-            x_max = max(x_max, x0 + pad * entry.x_extent)
-            y_min = min(y_min, y0 - pad * entry.y_extent)
-            y_max = max(y_max, y0 + pad * entry.y_extent)
+            lo = min(lo, x0 - pad * entry.x_extent, y0 - pad * entry.y_extent)
+            hi = max(hi, x0 + pad * entry.x_extent, y0 + pad * entry.y_extent)
 
-        ax.set_xlim(x_min, x_max)
-        ax.set_ylim(y_min, y_max)
+        ax.set_xlim(lo, hi)
+        ax.set_ylim(lo, hi)
 
         # Show legend if any patch has a non-private label
         if any(e.patch.get_label() and not e.patch.get_label().startswith("_") for e in self.entries):


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
Scale the resolution ellipses based on the min/max of each plot. May need to zoom in to see the picture.
<img width="1189" height="12389" alt="output" src="https://github.com/user-attachments/assets/96eb0fa6-d84f-44ed-885c-af1622b27a4a" />

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
